### PR TITLE
Preparation for Scala3: Explicitly import implicit class

### DIFF
--- a/src/main/resources/S3/ops_extension.scala
+++ b/src/main/resources/S3/ops_extension.scala
@@ -85,7 +85,10 @@ def upload(params: PutObjectRequest, options: managedupload.ManagedUploadOptions
  * Note that this is the only operation for which the SDK can retry requests with stream bodies.
  * @return The response data from the successful upload
  */
-def uploadFuture(params: PutObjectRequest): Future[managedupload.SendData] = service.upload(params).sendFuture()
+def uploadFuture(params: PutObjectRequest): Future[managedupload.SendData] = {
+  import facade.amazonaws.services.s3.managedupload.ManagedUploadOps
+  service.upload(params).sendFuture()
+}
 
 /**
  * Uploads an arbitrarily sized buffer, blob, or stream, using intelligent concurrent handling of parts if the payload is large enough.
@@ -93,4 +96,7 @@ def uploadFuture(params: PutObjectRequest): Future[managedupload.SendData] = ser
  * Note that this is the only operation for which the SDK can retry requests with stream bodies.
  * @return The response data from the successful upload
  */
-def uploadFuture(params: PutObjectRequest, options: managedupload.ManagedUploadOptions): Future[managedupload.SendData] = service.upload(params, options).sendFuture()
+def uploadFuture(params: PutObjectRequest, options: managedupload.ManagedUploadOptions): Future[managedupload.SendData] = {
+  import facade.amazonaws.services.s3.managedupload.ManagedUploadOps
+  service.upload(params, options).sendFuture()
+}


### PR DESCRIPTION
It looks like implicits resolution is slightly changed in Scala 3.