### PR TITLE
Check the digests of non-service directories

### DIFF
--- a/src/main/scala/com/leeriggins/awsapis/NonServiceClasses.scala
+++ b/src/main/scala/com/leeriggins/awsapis/NonServiceClasses.scala
@@ -1,0 +1,9 @@
+package com.leeriggins.awsapis
+
+/** Manages digests of directories except 'service'.
+  */
+object NonServiceClasses {
+  val digests = Map(
+    "credentials" -> "e672621e5760c254cf7868ac39b79fdc"
+  )
+}

--- a/src/main/scala/com/leeriggins/awsapis/NonServiceClasses.scala
+++ b/src/main/scala/com/leeriggins/awsapis/NonServiceClasses.scala
@@ -4,6 +4,20 @@ package com.leeriggins.awsapis
   */
 object NonServiceClasses {
   val digests = Map(
-    "credentials" -> "e672621e5760c254cf7868ac39b79fdc"
+    "credentials"                                          -> "068484345d4166706f0755746fce3c63",
+    "credentials/chainable_temporary_credentials.d.ts"     -> "625400713394777a36b62a338d7729aa",
+    "credentials/cognito_identity_credentials.d.ts"        -> "7551294d419c49e38e5c8df695d35fab",
+    "credentials/credential_provider_chain.d.ts"           -> "47418be991db6d116b1c264d79f01c4b",
+    "credentials/ec2_metadata_credentials.d.ts"            -> "ef6bbdccbc6be992a3510acece9ef50e",
+    "credentials/ecs_credentials.d.ts"                     -> "e8e9f110846359c86b56f85d49d1737d",
+    "credentials/environment_credentials.d.ts"             -> "f341528d9a3d561ec93df8330e27a77c",
+    "credentials/file_system_credentials.d.ts"             -> "ae7b64d4b3643793f206f443f08725a5",
+    "credentials/process_credentials.d.ts"                 -> "d162410290f8b326be0d1c008e0f9bdd",
+    "credentials/remote_credentials.d.ts"                  -> "182855a8e48a2ba4425302c6d872a82c",
+    "credentials/saml_credentials.d.ts"                    -> "a99c59fd6607b27b3f3a37a848d56423",
+    "credentials/shared_ini_file_credentials.d.ts"         -> "b06eab7acee130014f8d53b1f712d274",
+    "credentials/temporary_credentials.d.ts"               -> "d8c450ad0c53333011ee07933ed7f2a5",
+    "credentials/token_file_web_identity_credentials.d.ts" -> "7803a38e7368b08b499d719f07495828",
+    "credentials/web_identity_credentials.d.ts"            -> "15c734453e67888bf1f04dde1693ee53"
   )
 }

--- a/src/main/scala/com/leeriggins/awsapis/gen/ScalaJsGen.scala
+++ b/src/main/scala/com/leeriggins/awsapis/gen/ScalaJsGen.scala
@@ -2,6 +2,7 @@ package com.leeriggins.awsapis.gen
 
 import java.io._
 import java.nio.file.{Files, Path, Paths}
+import java.security.MessageDigest
 import java.util.stream.Collectors
 
 import scala.jdk.CollectionConverters._
@@ -9,6 +10,7 @@ import scala.jdk.CollectionConverters._
 import com.leeriggins.awsapis.models._
 import com.leeriggins.awsapis.models.AwsApiType._
 import com.leeriggins.awsapis.parser._
+import com.leeriggins.awsapis.NonServiceClasses
 
 import Apis._
 import org.json4s._
@@ -688,12 +690,36 @@ object ScalaJsGen {
       oldVersions.foreach { case (key, latestVersion) =>
         println(s""" "${key}" -> "${latestVersion}",  """)
       }
-      throw new Exception("Newer version found !!")
+      throw new Exception("Newer version found in services !!")
+    }
+  }
+
+  def checkNonServices(): Unit = {
+    val digester = MessageDigest.getInstance("MD5")
+    val anyUpdate = NonServiceClasses.digests
+      .map { case (directoryName, lastDigest) =>
+        val dirPath = Paths.get(s"aws-sdk-js/lib", directoryName)
+        Files.newDirectoryStream(dirPath).forEach { file =>
+          digester.update(Files.readAllBytes(file))
+        }
+        val digest = digester.digest().map(s => "%02x".format(s)).mkString
+        digester.reset()
+        if (digest != lastDigest) {
+          println(s"$dirPath: ${digest} ${lastDigest}")
+          true
+        } else {
+          false
+        }
+      }
+      .exists(_ == true)
+    if (anyUpdate) {
+      throw new Exception("Newer version found in non-services !!")
     }
   }
 
   def main(args: Array[String]): Unit = {
     checkNewService()
+    checkNonServices()
     generatePackageFile()
     generateAWSConfigWithServicesDefault()
     generateAllServicesTest()


### PR DESCRIPTION
Related to https://github.com/exoego/aws-sdk-scalajs-facade/issues/345

Currently, type facade are generated only for service classes.
This is because the generator parse service definition JSON and convert them into type facade.
However, some non-service classes are needed to work with service classes.
Example is sub classes of `Credential`s.
So, it is better to have type facade for non-service class.

This PR adds digest checker of non-service classes.
If digest unmatched, there are updates on types.
